### PR TITLE
Make multiblocks usable for other mods

### DIFF
--- a/src/main/java/net/borisshoes/arcananovum/core/Multiblock.java
+++ b/src/main/java/net/borisshoes/arcananovum/core/Multiblock.java
@@ -225,10 +225,14 @@ public class Multiblock {
       }
       return newPos.multiply(-1);
    }
+
+   public static Multiblock loadFromFile(String id) {
+      return loadFromFile(id, MOD_ID);
+   }
    
-   public static Multiblock loadFromFile(String id){
+   public static Multiblock loadFromFile(String id, String mod_id){
       try{
-         Optional<Optional<Path>> pathOptional = FabricLoader.getInstance().getModContainer(MOD_ID).map(container -> container.findPath("data/"+MOD_ID+"/multiblocks/"+id+".nbt"));
+         Optional<Optional<Path>> pathOptional = FabricLoader.getInstance().getModContainer(mod_id).map(container -> container.findPath("data/"+MOD_ID+"/multiblocks/"+id+".nbt"));
          if(pathOptional.isEmpty() || pathOptional.get().isEmpty()){
             return null;
          }

--- a/src/main/java/net/borisshoes/arcananovum/core/Multiblock.java
+++ b/src/main/java/net/borisshoes/arcananovum/core/Multiblock.java
@@ -232,7 +232,7 @@ public class Multiblock {
    
    public static Multiblock loadFromFile(String id, String mod_id){
       try{
-         Optional<Optional<Path>> pathOptional = FabricLoader.getInstance().getModContainer(mod_id).map(container -> container.findPath("data/"+MOD_ID+"/multiblocks/"+id+".nbt"));
+         Optional<Optional<Path>> pathOptional = FabricLoader.getInstance().getModContainer(mod_id).map(container -> container.findPath("data/"+mod_id+"/multiblocks/"+id+".nbt"));
          if(pathOptional.isEmpty() || pathOptional.get().isEmpty()){
             return null;
          }


### PR DESCRIPTION
I am coding an add on, but in Multiblock.java the loadFromFile() only loads from arcana novum. This pull request makes it so you can optionally provide a mod id to get the multiblock file from.