### PR TITLE
Fix crash

### DIFF
--- a/src/main/java/net/borisshoes/arcananovum/mixins/StructurePoolAccessor.java
+++ b/src/main/java/net/borisshoes/arcananovum/mixins/StructurePoolAccessor.java
@@ -1,9 +1,9 @@
 package net.borisshoes.arcananovum.mixins;
 
+import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.structure.pool.StructurePool;
 import net.minecraft.structure.pool.StructurePoolElement;
-import net.minecraft.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/java/net/borisshoes/arcananovum/world/structures/FabricStructurePoolImpl.java
+++ b/src/main/java/net/borisshoes/arcananovum/world/structures/FabricStructurePoolImpl.java
@@ -1,10 +1,10 @@
 package net.borisshoes.arcananovum.world.structures;
 
+import com.mojang.datafixers.util.Pair;
 import net.borisshoes.arcananovum.mixins.StructurePoolAccessor;
 import net.minecraft.structure.pool.StructurePool;
 import net.minecraft.structure.pool.StructurePoolElement;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.Pair;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
The game stores template pool element weights in a `List<Pair<..., ...>>`. `Pair` is specifically the object from the **DFU** library.

In the accessor, you import `Pair` from the **base Minecraft code**. This PR just imports the correct `Pair`.