### PR TITLE
Fix starlight forge crafting issue and related issues

### DIFF
--- a/src/main/java/net/borisshoes/arcananovum/blocks/altars/CelestialAltarBlockEntity.java
+++ b/src/main/java/net/borisshoes/arcananovum/blocks/altars/CelestialAltarBlockEntity.java
@@ -106,7 +106,7 @@ public class CelestialAltarBlockEntity extends BlockEntity implements PolymerObj
       
       int phase = this.getPhase();
       int mode = this.getMode();
-      long timeOfDay = serverWorld.getGameTime();
+      long timeOfDay = serverWorld.getOverworldClockTime();
       if(mode == 0){
          int curTime = (int) (timeOfDay % 24000L);
          int targetTime = TIMES[phase];

--- a/src/main/java/net/borisshoes/arcananovum/blocks/forge/StarlightForgeBlockEntity.java
+++ b/src/main/java/net/borisshoes/arcananovum/blocks/forge/StarlightForgeBlockEntity.java
@@ -225,7 +225,7 @@ public class StarlightForgeBlockEntity extends BlockEntity implements PolymerObj
    public int getPlanetCount(){
       int planetCount = 2;
       if(ArcanaAugments.getAugmentFromMap(getAugments(), ArcanaAugments.MOONLIT_FORGE) >= 1){
-         long timeOfDay = level.getGameTime();
+         long timeOfDay = level.getOverworldClockTime();
          int day = (int) (timeOfDay / 24000L % Integer.MAX_VALUE);
          int curPhase = day % 8;
          int influence = Math.abs(-curPhase + 4);
@@ -248,7 +248,7 @@ public class StarlightForgeBlockEntity extends BlockEntity implements PolymerObj
    public int getStarCount(){
       int starCount = 2;
       if(ArcanaAugments.getAugmentFromMap(getAugments(), ArcanaAugments.MOONLIT_FORGE) >= 1){
-         long timeOfDay = level.getGameTime();
+         long timeOfDay = level.getOverworldClockTime();
          int day = (int) (timeOfDay / 24000L % Integer.MAX_VALUE);
          int curPhase = day % 8;
          int influence = Math.abs(-curPhase + 4);

--- a/src/main/java/net/borisshoes/arcananovum/datastorage/ArcanaPlayerData.java
+++ b/src/main/java/net/borisshoes/arcananovum/datastorage/ArcanaPlayerData.java
@@ -1414,7 +1414,7 @@ public class ArcanaPlayerData implements StorableData {
             gEventFound.setStage(2);
             BorisLib.addTickTimerCallback(new GenericTimer(120, () -> {
                ServerLevel overworld = player.level().getServer().overworld();
-               long timeOfDay = overworld.getGameTime();
+               long timeOfDay = overworld.getOverorldClockTime();
                int curTime = (int) (timeOfDay % 24000L);
                int targetTime = 18000;
                int timeDiff = (targetTime - curTime + 24000) % 24000;

--- a/src/main/java/net/borisshoes/arcananovum/mixins/ItemEntityMixin.java
+++ b/src/main/java/net/borisshoes/arcananovum/mixins/ItemEntityMixin.java
@@ -97,7 +97,7 @@ public class ItemEntityMixin {
             }
          }
          
-         long timeOfDay = serverWorld.getGameTime();
+         long timeOfDay = serverWorld.getOverworldClockTime();
          int day = (int) (timeOfDay / 24000L % Integer.MAX_VALUE);
          int curTime = (int) (timeOfDay % 24000L);
          int curPhase = day % 8;


### PR DESCRIPTION
The game time is used a few times instead of the overworld clock time, introduced in the update to 26.1 when the getDayTime method was renamed in minecraft's source. This made the moon phase and time checking for starlight forge crafting inaccurate. It also messed up other things that vary with moon phase and time of day. This PR makes the mod use daytime instead of game time when it should.